### PR TITLE
Some tasks load in a different URL

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -27,7 +27,8 @@
         {
             "matches": [
                 "http://genome.klick.com/tickets/*",
-                "https://genome.klick.com/tickets/*"
+                "https://genome.klick.com/tickets/*",
+                "https://genome.klick.com/conductor/task/#/details/*"
             ],
             "js": [
                 "scripts/genomeTasks-bundle.js"


### PR DESCRIPTION
There is a new app in genome called Conductor, and if a project is from this app, then the url changes to `https://genome.klick.com/conductor/task/#/details/TICKET_ID` thus not showing the gscheduler button.